### PR TITLE
User specific file/folder exclusions

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -303,15 +303,17 @@ class TodoCommand(sublime_plugin.TextCommand):
         window = self.view.window()
         settings = Settings(self.view.settings().get('todo', {}))
 
+
         ## TODO: Cleanup this init code. Maybe move it to the settings object
         filepaths, dirpaths = self.search_paths(window)
 
+        ignored_dirs = settings.get('folder_exclude_patterns', [])
         ## Get exclude patterns from global settings
         ## Is there really no better way to access global settings?
         global_settings = sublime.load_settings('Global.sublime-settings')
-        ignored_dirs = global_settings.get('folder_exclude_patterns', [])
+        ignored_dirs.extend(global_settings.get('folder_exclude_patterns', []))
 
-        exclude_file_patterns = []
+        exclude_file_patterns = settings.get('file_exclude_patterns', [])
         exclude_file_patterns.extend(global_settings.get('file_exclude_patterns', []))
         exclude_file_patterns.extend(global_settings.get('binary_file_patterns', []))
         exclude_file_patterns = [fnmatch.translate(patt) for patt in exclude_file_patterns]


### PR DESCRIPTION
In order to exclude folders and files from crawling, this pull request allows you to specify a list of folders and/or files in the following manner.

In your `Base File.sublime-settings` (User overrides)

``` json
{
    "todo": {
      "folder_exclude_patterns": [
        "vendor",
        "log",
        "tmp",
        ".bundle",
        "public",
        "doc"
      ],
      "file_exclude_patterns": ["*.css"]
    }
}
```

as well as your project specific configurations e.g. `My Project.sublime-project`

``` json
{
  "folders": [
    {
      "path": "/Users/awesome/Projects/foo"
    }
  ],
  "settings" : {
    "todo": {
      "folder_exclude_patterns": [
        "vendor",
        "log",
        "tmp",
        ".bundle",
        "public",
        "doc"
      ],
      "file_exclude_patterns": ["*.css"]
    }
  }
}
```

This way you can have separate exclusions for TODOs (like suggested in #11) and still honour the global excludes like `.git` and `.svn`
