### PR TITLE
Fixing issue #13. Appeared on some locales with non-ASCII texts.

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -199,7 +199,7 @@ class TodoRenderer(object):
     def header(self):
         hr = u'+ {0} +'.format('-' * 76)
         return u'{hr}\n| TODOS @ {0:<68} |\n| {1:<76} |\n{hr}\n'.format(
-            datetime.utcnow().strftime('%A %d %B %Y %H:%M'),
+            datetime.utcnow().strftime('%A %d %B %Y %H:%M').decode("utf-8"),
             u'{0} files scanned'.format(self.file_counter),
             hr=hr)
 


### PR DESCRIPTION
Issue #13: TODO extracting doesn't work

This bug appeared, if the user uses a locale with non-ASCII characters
in date / time texts. Since UTF-8 is (IMHO) the default encoding of
Sublime Text 2, explicitly decoding the result as UTF-8 should now
return a valid unicode string and not longer raise a
UnicodeDecodeError.
