### PR TITLE
Add Vim Style Key Bindings to Todo List navigation

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -24,6 +24,15 @@
         ],
         "args": {"direction": "forward"}
     },
+    
+    {
+        "keys": ["j"], "command": "navigate_results",
+        "context": [
+            {"key": "setting.command_mode", "operand": true}
+            // {"key": "setting.todo_results"}
+        ],
+        "args": {"direction": "forward"}
+    },
 
     {
         "keys": ["p"], "command": "navigate_results",
@@ -36,6 +45,15 @@
 
     {
         "keys": ["up"], "command": "navigate_results",
+        "context": [
+            {"key": "setting.command_mode", "operand": true}
+            //{"key": "setting.todo_results"}
+        ],
+        "args": {"direction": "backward"}
+    },
+
+    {
+        "keys": ["k"], "command": "navigate_results",
         "context": [
             {"key": "setting.command_mode", "operand": true}
             //{"key": "setting.todo_results"}

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -24,6 +24,15 @@
         ],
         "args": {"direction": "forward"}
     },
+    
+    {
+        "keys": ["j"], "command": "navigate_results",
+        "context": [
+            {"key": "setting.command_mode", "operand": true}
+            // {"key": "setting.todo_results"}
+        ],
+        "args": {"direction": "forward"}
+    },
 
     {
         "keys": ["p"], "command": "navigate_results",
@@ -36,6 +45,15 @@
 
     {
         "keys": ["up"], "command": "navigate_results",
+        "context": [
+            {"key": "setting.command_mode", "operand": true}
+            //{"key": "setting.todo_results"}
+        ],
+        "args": {"direction": "backward"}
+    },
+
+    {
+        "keys": ["k"], "command": "navigate_results",
         "context": [
             {"key": "setting.command_mode", "operand": true}
             //{"key": "setting.todo_results"}

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -24,6 +24,15 @@
         ],
         "args": {"direction": "forward"}
     },
+    
+    {
+        "keys": ["j"], "command": "navigate_results",
+        "context": [
+            {"key": "setting.command_mode", "operand": true}
+            // {"key": "setting.todo_results"}
+        ],
+        "args": {"direction": "forward"}
+    },
 
     {
         "keys": ["p"], "command": "navigate_results",
@@ -36,6 +45,15 @@
 
     {
         "keys": ["up"], "command": "navigate_results",
+        "context": [
+            {"key": "setting.command_mode", "operand": true}
+            //{"key": "setting.todo_results"}
+        ],
+        "args": {"direction": "backward"}
+    },
+
+    {
+        "keys": ["k"], "command": "navigate_results",
         "context": [
             {"key": "setting.command_mode", "operand": true}
             //{"key": "setting.todo_results"}


### PR DESCRIPTION
Just a quick keymap change to add vim style bindings to navigate the todo list.
