### PR TITLE
Add keypad enter key to results navigation

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -75,6 +75,13 @@
             {"key": "setting.command_mode", "operand": true}
             // {"key": "setting.todo_results"}
         ]
-    }
+    },
 
+    {
+        "keys": ["keypad_enter"], "command": "goto_comment",
+        "context": [
+            {"key": "setting.command_mode", "operand": true}
+            // {"key": "setting.todo_results"}
+        ]
+    }
 ]


### PR DESCRIPTION
I tend to use the arrow keys and the keypad enter key when navigating the search results.  Thought it would be nice for others if I push that back to you.

mike
