### PR TITLE
Fixed Github download URL

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -11,7 +11,7 @@
                 "*": [
                     {
                         "version": "1.1.3",
-                        "url": "https://nodeload.github.com/robcowie/SublimeTODO/zipball/1.1.3"
+                        "url": "https://codeload.github.com/robcowie/SublimeTODO/zip/1.1.3"
                     }
                 ]
             }


### PR DESCRIPTION
Fixed github download URL (was a 400).

This makes #63 obsolete. The difference between #63 and this PR is the filename of the downloaded zip (`SublimeTODO-1.1.3.zip` for this PR vs `robcowie-SublimeTODO-1.1.3-0-gdd699a4.zip` for #63). Don't know if that will actually make a difference.
